### PR TITLE
add suppress warning for char cast in UtilMDE.java line 2665

### DIFF
--- a/java/src/plume/UtilMDE.java
+++ b/java/src/plume/UtilMDE.java
@@ -2662,7 +2662,11 @@ public final class UtilMDE {
             if ((ch < '0') || (ch > '8')) {
               break;
             }
-            octal_char = (char) ((octal_char * 8) + Character.digit(ch, 8));
+            /* cast warning is suppressed here because It's not possible for Character.digit to return -1
+            as `ch` is within the radix range */
+	        @SuppressWarnings("cast")
+	        char octal_char_cast = (char) ((octal_char * 8) + Character.digit(ch, 8));
+	        octal_char = octal_char_cast;
           }
           sb.append(octal_char);
           post_esc = ii - 1;


### PR DESCRIPTION
suppress warning added to suppress below warning. This warning occurs when we defines a range for `char`. (@IntRange(from=0, to=65535))
```
src/plume/UtilMDE.java:2665: warning: [cast.unsafe] "@GTENegativeOne int" may not be casted to the type "@NonNegative char"
            octal_char = (char) ((octal_char * 8) + Character.digit(ch, 8));
                         ^
```
We can suppress this warning because `Character.digit` will not return `-1` as the values of `ch` has already being checked before calling the method.